### PR TITLE
chore(cd): add continuous delivery and auto merge dependabot PRs

### DIFF
--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -1,0 +1,37 @@
+# auto merge workflow.
+#
+# Auto merge PR if commit msg begins with `chore(release):`,
+# or if it has been raised by Dependabot.
+# Uses https://github.com/ridedott/merge-me-action.
+
+name: Merge Version Change and Dependabot PRs automatically
+
+on: pull_request
+
+jobs:
+  merge:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+
+    - name: get commit message
+      run: |
+           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
+    - name: show commit message
+      run : echo $commitmsg
+
+    - name: Merge Version change PR
+      if: startsWith( env.commitmsg, 'chore(release):')
+      uses: ridedott/merge-me-action@81667e6ae186ddbe6d3c3186d27d91afa7475e2c
+      with:
+        GITHUB_LOGIN: dirvine
+        GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        MERGE_METHOD: REBASE
+
+    - name: Dependabot Merge
+      uses: ridedott/merge-me-action@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MERGE_METHOD: REBASE

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,24 @@
+name: Version bump and create PR for changes
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-20.04
+    # Dont run if we're on a release commit
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump Version
+        uses: maidsafe/rust-version-bump-branch-creator@v2
+        with:
+          token: ${{ secrets.BRANCH_CREATOR_TOKEN }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Commitlint
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,37 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    # only if we have a tag
+    name: Release
+    runs-on: ubuntu-20.04
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      - name: Set tag as env
+        shell: bash
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+
+      - name: lets check tag
+        shell: bash
+        run: echo ${{ env.RELEASE_VERSION }}
+
+      - name: Generate Changelog
+        shell: bash
+        run: awk '/# \[/{c++;p=1}{if(c==2){exit}}p;' CHANGELOG.md > RELEASE-CHANGELOG.txt
+      - run: cat RELEASE-CHANGELOG.txt
+      - name: Release generation
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        with:
+          body_path: RELEASE-CHANGELOG.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -51,17 +51,18 @@ jobs:
       - name: Cargo Build
         run: cargo build --release
 
+  # Publish if we're on a release commit
   publish:
     name: Publish
     runs-on: ubuntu-latest
     needs: build
-    # Is this a version change commit?
-    if: startsWith(github.event.head_commit.message, 'Version change')
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
     steps:
       - uses: actions/checkout@v2
       # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
         with:
           fetch-depth: '0'
+     
       # Install Rust
       - uses: actions-rs/toolchain@v1
         with:
@@ -69,23 +70,9 @@ jobs:
           toolchain: stable
           override: true
 
-      # Set the tag.
-      - shell: bash
-        id: versioning
-        run: |
-          version=$(grep "^version" < Cargo.toml | head -n 1 | awk '{ print $3 }' | sed 's/\"//g')
-          echo "Current version: $version"
-          echo "::set-output name=version::$version"
-      - name: Push version tag
-        uses: anothrNick/github-tag-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CUSTOM_TAG: ${{ steps.versioning.outputs.version }}
-
       # Publish to crates.io.
-      - name: Cargo package
-        run: cargo package
-      - name: Cargo publish
-        env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CRATES_IO_TOKEN }}
-        run: cargo publish --token $CARGO_REGISTRY_TOKEN
+      - name: Cargo Login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Cargo Publish
+        run: cargo publish

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,37 @@
+name: Tag release commit
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+  GITHUB_TOKEN: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+
+jobs:
+  tag:
+      runs-on: ubuntu-latest
+      # Only run on a release commit
+      if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: '0'
+            token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+        - run: echo ::set-env name=RELEASE_VERSION::$(git log -1 --pretty=%B)
+        # parse out non-tag text
+        - run: echo ::set-env name=RELEASE_VERSION::$( echo $RELEASE_VERSION | sed 's/chore(release)://' )
+        # remove spaces, but add back in `v` to tag, which is needed for standard-version
+        - run: echo ::set-env name=RELEASE_VERSION::v$(echo $RELEASE_VERSION | tr -d '[:space:]')
+        - run: echo $RELEASE_VERSION
+        - run: git tag $RELEASE_VERSION
+
+        - name: Setup git for push
+          run: |
+            git remote add github "$REPO"
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+        - name: Push tags to master
+          run: git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:master --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,83 +1,83 @@
-# FFI utils - Change Log
+# FFI utils - Changelog
 
-# [0.18.0]
-- Update crate name to sn_ffi_utils
+### [0.18.0](https://github.com/maidsafe/sn_ffi_utils/compare/0.17.0...0.18.0) (2020-09-02)
+* Update crate name to sn_ffi_utils
 
-# [0.17.0]
-- Log panics in logs
-- Update multiple dependencies
+### [0.17.0]
+* Log panics in logs
+* Update multiple dependencies
 
-# [0.16.0]
-- Update `walkdir` dependency
+### [0.16.0]
+* Update `walkdir` dependency
 
-## [0.15.0]
-- Add full support for new macro import style in calling crates
+### [0.15.0]
+* Add full support for new macro import style in calling crates
 
-## [0.14.0]
-- Improve performance by removing unnecessary call to `format!`
-- Add ReprC impls for other array lengths and booleans
+### [0.14.0]
+* Improve performance by removing unnecessary call to `format!`
+* Add ReprC impls for other array lengths and booleans
 
-## [0.13.0]
-- Make `vec_into_raw_parts` not return a capacity
-- Add `vec_from_raw_parts`
-- Remove `from_c_str`
+### [0.13.0]
+* Make `vec_into_raw_parts` not return a capacity
+* Add `vec_from_raw_parts`
+* Remove `from_c_str`
 
-## [0.12.0]
-- Use stable rustc, clippy, and rustfmt
-- Upgrade crate to Rust 2018 edition
-- Fix compiler and clippy errors
-- Update jni to 0.12.0
-- Introduce `NativeResult` type
-- Change macros to interface with `NativeResult`
-- Move `TestError` to test_utils.rs
-- Add `ReprC` implementation for `i32` and `i64` types
+### [0.12.0]
+* Use stable rustc, clippy, and rustfmt
+* Upgrade crate to Rust 2018 edition
+* Fix compiler and clippy errors
+* Update jni to 0.12.0
+* Introduce `NativeResult` type
+* Change macros to interface with `NativeResult`
+* Move `TestError` to test_utils.rs
+* Add `ReprC` implementation for `i32` and `i64` types
 
-## [0.11.0]
-- Fix leaking local references in the Java module. Because the Android local reference table is limited to 512
+### [0.11.0]
+* Fix leaking local references in the Java module. Because the Android local reference table is limited to 512
   entries it is important to deallocate the local references as soon as possible.
 
-## [0.10.0]
-- Make the `java` module feature-gated. This should optimise build times for dependent crates which don't require Java/JNI support
-- Add a new helper enum `EnvGuard` that simplifies JNI env management (acquiring, holding the reference, and deallocating it automatically)
-- Make JNI code safer and cleaner
+### [0.10.0]
+* Make the `java` module feature-gated. This should optimise build times for dependent crates which don't require Java/JNI support
+* Add a new helper enum `EnvGuard` that simplifies JNI env management (acquiring, holding the reference, and deallocating it automatically)
+* Make JNI code safer and cleaner
 
-## [0.9.0]
-- Support providing custom class loader in Java/JNI routines and macros
+### [0.9.0]
+* Support providing custom class loader in Java/JNI routines and macros
 
-## [0.8.0]
-- Update to dual license (MIT/BSD)
-- Upgrade unwrap version to 1.2.0
-- Use rust 1.28.0 stable / 2018-07-07 nightly
-- rustfmt 0.99.2 and clippy-0.0.212
+### [0.8.0]
+* Update to dual license (MIT/BSD)
+* Upgrade unwrap version to 1.2.0
+* Use rust 1.28.0 stable / 2018-07-07 nightly
+* rustfmt 0.99.2 and clippy-0.0.212
 
-## [0.7.0]
-- Add a public helper function `catch_unwind_result` for synchronous APIs (in addition to `catch_unwind_cb` for async)
+### [0.7.0]
+* Add a public helper function `catch_unwind_result` for synchronous APIs (in addition to `catch_unwind_cb` for async)
 
-## [0.6.0]
-- Use rust 1.26.1 stable / 2018-02-29 nightly
-- rustfmt-nightly 0.8.2 and clippy-0.0.206
-- Updated license from dual Maidsafe/GPLv3 to GPLv3
-- Add binding generator utilities
+### [0.6.0]
+* Use rust 1.26.1 stable / 2018-02-29 nightly
+* rustfmt-nightly 0.8.2 and clippy-0.0.206
+* Updated license from dual Maidsafe/GPLv3 to GPLv3
+* Add binding generator utilities
 
-## [0.5.0]
-- Use rust 1.22.1 stable / 2018-01-10 nightly
-- rustfmt 0.9.0 and clippy-0.0.179
-- `catch_unwind_error_code` function removed as it was no longer used
+### [0.5.0]
+* Use rust 1.22.1 stable / 2018-01-10 nightly
+* rustfmt 0.9.0 and clippy-0.0.179
+* `catch_unwind_error_code` function removed as it was no longer used
 
-## [0.4.0]
-- Use pointers to `FfiResult` instead of passing by value
-- Change type of `FFI_RESULT_OK` to a static reference
-- Don't add padding to URIs
-- Update base64 version
-- Add support for using a single user data parameter for multiple callbacks
-- Add tests for the `catch_unwind` family of functions
+### [0.4.0]
+* Use pointers to `FfiResult` instead of passing by value
+* Change type of `FFI_RESULT_OK` to a static reference
+* Don't add padding to URIs
+* Update base64 version
+* Add support for using a single user data parameter for multiple callbacks
+* Add tests for the `catch_unwind` family of functions
 
-## [0.3.0]
-- Improve documentation and fix bugs
-- Fix compiler errors on rustc-nightly
+### [0.3.0]
+* Improve documentation and fix bugs
+* Fix compiler errors on rustc-nightly
 
-## [0.2.0]
-- Change the log output for FFI errors - remove the decoration and reduce the log level
+### [0.2.0]
+* Change the log output for FFI errors - remove the decoration and reduce the log level
 
-## [0.1.0]
-- Provide FFI utility functions for safe_client_libs
+### [0.1.0]
+* Provide FFI utility functions for safe_client_libs


### PR DESCRIPTION
Implement a CD process where any PR merged to master will
automatically trigger a crate publish, a tag, a 'chore(release):'
PR which is auto merged, and a GitHub release.
This PR also adds auto merging for dependabot PRs which pass CI.
This PR also reformats the changelog to match the newly auto
generated format.